### PR TITLE
Remove obsolete NEXT_PUBLIC_ENVIRONMENT property

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,7 @@ NEXT_PUBLIC_MULTIMINT=true
 NEXT_PUBLIC_MAXMINTAMOUNT=15
 # Is provided to you by the ui when initializing
 NEXT_PUBLIC_LUT=
-NEXT_PUBLIC_ENVIRONMENT=devnet
 NEXT_PUBLIC_RPC=https://api.devnet.solana.com
 NEXT_PUBLIC_BUYMARKBEER=true
-#NEXT_PUBLIC_ENVIRONMENT=mainnet-beta
 #NEXT_PUBLIC_RPC=https://solana-mainnet.rpc.extrnode.com
 NEXT_PUBLIC_MICROLAMPORTS=1001

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,3 @@
-import { WalletAdapterNetwork } from "@solana/wallet-adapter-base";
 import { WalletProvider } from "@solana/wallet-adapter-react";
 import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 import type { AppProps } from "next/app";
@@ -11,21 +10,11 @@ import { ChakraProvider } from '@chakra-ui/react'
 import { image, headerText } from 'settings'
 import { SolanaTimeProvider } from "@/utils/SolanaTimeContext";
 
-
 export default function App({ Component, pageProps }: AppProps) {
-  let network = WalletAdapterNetwork.Devnet;
-  if (process.env.NEXT_PUBLIC_ENVIRONMENT === "mainnet-beta" || process.env.NEXT_PUBLIC_ENVIRONMENT === "mainnet") {
-    network = WalletAdapterNetwork.Mainnet;
-  }
   let endpoint = "https://api.devnet.solana.com";
   if (process.env.NEXT_PUBLIC_RPC) {
     endpoint = process.env.NEXT_PUBLIC_RPC;
   }
-  const wallets = useMemo(
-    () => [
-    ],
-    []
-  );
   return (
     <>
       <Head>
@@ -46,7 +35,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <ChakraProvider>
-        <WalletProvider wallets={wallets}>
+        <WalletProvider wallets={[]}>
           <UmiProvider endpoint={endpoint}>
             <WalletModalProvider>
               <SolanaTimeProvider>


### PR DESCRIPTION
This patch removes the unused `NEXT_PUBLIC_ENVIRONMENT` env var and related code as it was no longer needed in the app.